### PR TITLE
Test Test95.xls from t/excel_files

### DIFF
--- a/t/01_parse.t
+++ b/t/01_parse.t
@@ -34,7 +34,7 @@ BEGIN { $tests += 1; }
 
 my $workbook_1;
 {
-    my $workbook = Spreadsheet::ParseExcel::Workbook->Parse('sample/Excel/Test95.xls');
+    my $workbook = Spreadsheet::ParseExcel::Workbook->Parse('t/excel_files/Test95.xls');
     $workbook_1 = $workbook;
     use Data::Dumper;
     #diag Dumper $excel;
@@ -67,7 +67,7 @@ my $workbook_1;
 
     is($workbook->{Version}, 1280);
     is($workbook->{BIFFVersion}, 8);
-    is($workbook->{File}, 'sample/Excel/Test95.xls');
+    is($workbook->{File}, 't/excel_files/Test95.xls');
     is($workbook->{Author}, 'kawait');
 
 


### PR DESCRIPTION
t/01_parse.t used sample/Excel/Test95.xls, while there was a completely identical t/excel_files/Test95.xls file.

To make the tests self-contained this patch changes the test to use the file from t/excel_files directory.